### PR TITLE
Download multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,19 @@ Onion services are fully supported.
     Copyright © 2021-2023 Michał Trojnara <Michal.Trojnara@stunnel.org>
     Licensed under GNU/GPL version 3
 
-    Usage: torget [FLAGS] URL [URL2...]
-    -circuits, -c int
-          Concurrent circuits. (default 20)
-    -destination, -d string
-          Output directory. (default current directory)
-    -force bool
-          Will create parent folder(s) and/or overwrite existing files.
-    -min-lifetime, -l int
-          Minimum circuit lifetime (seconds). (default 10)
-    -name, -n string
-          Output filename. (default filename from URL)
-    -verbose, -v
-          Show diagnostic details.
+    Usage: torget [FLAGS] {file.txt | URL [URL2...]}
+      -circuits, -c int
+            Concurrent circuits. (default 20)
+      -destination, -d string
+            Output directory. (default current directory)
+      -force bool
+            Will create parent folder(s) and/or overwrite existing files.
+      -min-lifetime, -l int
+            Minimum circuit lifetime (seconds). (default 10)
+      -name, -n string
+            Output filename. (default filename from URL)
+      -verbose, -v
+            Show diagnostic details.
 
 ### Download a file to the current directory
     $ ./torget "https://archive.org/download/grimaces-birthday-game/Grimace%27s%20Birthday%20%28World%29%20%28v1.7%29%20%28Aftermarket%29%20%28Unl%29.gbc"

--- a/README.md
+++ b/README.md
@@ -17,13 +17,14 @@ Onion services are fully supported.
     $ go build torget.go
 
 ## Using
+
 ### View help page
     $ ./torget -h
     torget 2.0, a fast large file downloader over locally installed Tor
     Copyright © 2021-2023 Michał Trojnara <Michal.Trojnara@stunnel.org>
     Licensed under GNU/GPL version 3
 
-    Usage: torget [FLAGS] URL
+    Usage: torget [FLAGS] URL [URL2...]
     -circuits, -c int
           Concurrent circuits. (default 20)
     -destination, -d string
@@ -72,3 +73,26 @@ If the file already exists, you will receive an error.
 
     ERROR: "/movies/Big Buck Bunny - Sunflower version (2013)/Big Buck Bunny - Sunflower Version (2013).mp4" already exists.
     exit status 1
+
+## Downloading Multiple Files
+
+### With multiple URLs as arguments
+You may pass more than one URL to torget and download them all.
+
+    $ ./torget -destination "/music" "https://archive.org/download/ca200_cjazz/ca200_Various__Clinical_Jazz_CD1.zip" "https://archive.org/download/ca200_cjazz/ca200_Various__Clinical_Jazz_CD2v.zip" "https://archive.org/download/ca200_cjazz/ca200_Various__Clinical_Jazz_CD3.zip"
+    Downloading 3 files.
+
+    [1/3] - https://archive.org/download/ca200_cjazz/ca200_Various__Clinical_Jazz_CD1.zip
+    Output file: /music/ca200_Various__Clinical_Jazz_CD1.zip
+    Download length: 177206596 bytes
+    Download complete
+    
+    [2/3] - https://archive.org/download/ca200_cjazz/ca200_Various__Clinical_Jazz_CD2v.zip
+    Output file: /music/ca200_Various__Clinical_Jazz_CD2v.zip
+    Download length: 142228026 bytes
+    Download complete
+    
+    [3/3] - https://archive.org/download/ca200_cjazz/ca200_Various__Clinical_Jazz_CD3.zip
+    Output file: /music/ca200_Various__Clinical_Jazz_CD3.zip
+    Download length: 152713364 bytes
+    Download complete

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ If the file already exists, you will receive an error.
 ## Downloading Multiple Files
 
 ### With multiple URLs as arguments
-You may pass more than one URL to torget and download them all.
+You may pass more than one URL to torget and download them all sequentially.
 
     $ ./torget -destination "/music" "https://archive.org/download/ca200_cjazz/ca200_Various__Clinical_Jazz_CD1.zip" "https://archive.org/download/ca200_cjazz/ca200_Various__Clinical_Jazz_CD2v.zip" "https://archive.org/download/ca200_cjazz/ca200_Various__Clinical_Jazz_CD3.zip"
     Downloading 3 files.
@@ -95,4 +95,33 @@ You may pass more than one URL to torget and download them all.
     [3/3] - https://archive.org/download/ca200_cjazz/ca200_Various__Clinical_Jazz_CD3.zip
     Output file: /music/ca200_Various__Clinical_Jazz_CD3.zip
     Download length: 152713364 bytes
+    Download complete
+
+### With a local text file
+You may pass the path of a text file containing multiple URLs on each line to download them all sequentially.
+
+#### /music/downloads.txt
+    
+    https://archive.org/download/ca200_cjazz/ca200_Various__Clinical_Jazz_CD4.zip
+    https://archive.org/download/ca200_cjazz/ca200_Various__Clinical_Jazz_CD5.zip
+    https://archive.org/download/ca200_cjazz/ca200_Various__Clinical_Jazz_CD6.zip
+
+#### Run torget
+
+    $ torget -destination "/music" "/music/downloads.txt"
+    Downloading 3 files.
+
+    [1/3] - https://archive.org/download/ca200_cjazz/ca200_Various__Clinical_Jazz_CD4.zip
+    Output file: /music/ca200_Various__Clinical_Jazz_CD4.zip
+    Download length: 163400499 bytes
+    Download complete
+    
+    [2/3] - https://archive.org/download/ca200_cjazz/ca200_Various__Clinical_Jazz_CD5.zip
+    Output file: /music/ca200_Various__Clinical_Jazz_CD5.zip
+    Download length: 160286763 bytes
+    Download complete
+    
+    [3/3] - https://archive.org/download/ca200_cjazz/ca200_Various__Clinical_Jazz_CD6.zip
+    Output file: /music/ca200_Various__Clinical_Jazz_CD6.zip
+    Download length: 166744974 bytes
     Download complete

--- a/torget.go
+++ b/torget.go
@@ -139,11 +139,12 @@ func (s *State) chunkFetch(id int, client *http.Client, req *http.Request) {
 
 	// open the output file
 	file, err := os.OpenFile(s.output, os.O_WRONLY, 0)
-	defer file.Close()
 	if err != nil {
 		s.log <- fmt.Sprintf("os OpenFile: %s", err.Error())
 		return
 	}
+	defer file.Close()
+
 	_, err = file.Seek(s.chunks[id].start, io.SeekStart)
 	if err != nil {
 		s.log <- fmt.Sprintf("File Seek: %s", err.Error())
@@ -562,16 +563,17 @@ func main() {
 
 	// Iterate over each URL passed as an argument and download the file
 	for i, uri := range uris {
-		fmt.Println()
 		_, err := url.ParseRequestURI(uri)
 		if err != nil {
 			fmt.Printf("ERROR: \"%s\" is not a valid URL.\n", uri)
 			continue
 		}
 
-		state := NewState(ctx)
+		if len(uris) < 1 {
+			fmt.Printf("\n[%d/%d] - %s\n", i+1, len(uris), uri)
+		}
 
-		fmt.Printf("[%d/%d] - %s\n", i+1, len(uris), uri)
+		state := NewState(ctx)
 		state.Fetch(uri)
 	}
 }

--- a/torget.go
+++ b/torget.go
@@ -492,7 +492,7 @@ func init() {
 		fmt.Fprintln(os.Stderr, "Copyright © 2021-2023 Michał Trojnara <Michal.Trojnara@stunnel.org>")
 		fmt.Fprintln(os.Stderr, "Licensed under GNU/GPL version 3")
 		fmt.Fprintln(os.Stderr)
-		fmt.Fprintln(os.Stderr, "Usage: torget [FLAGS] file.txt | URL [URL2...]")
+		fmt.Fprintln(os.Stderr, "Usage: torget [FLAGS] {file.txt | URL [URL2...]}")
 
 		// Custom print out of the arguments to avoid duplicate entries for long and short versions
 		fmt.Fprintln(os.Stderr, "  -circuits, -c int")


### PR DESCRIPTION
Added the ability to download multiple files in two ways:

- Pass multiple URLs as non-flag arguments: `torget "url1" "url2"`
- Pass a text file with one URL per line as the non-flag argument: `torget "/path/to/file.txt"`