### PR TITLE
Housekeeping small changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,13 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# General folder for odds and ends that don't need to be comitted
+/ignore/
+
+# Emacs backup files
+*~
+\#*\#
+
+# VS Code folder
+.vscode/

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
-# General folder for odds and ends that don't need to be comitted
+# General folder for odds and ends that don't need to be committed.
 /ignore/
 
 # Emacs backup files

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Onion services are fully supported.
     $ ./torget -h
     torget 2.0, a fast large file downloader over locally installed Tor
     Copyright © 2021-2023 Michał Trojnara <Michal.Trojnara@stunnel.org>
-    Licensed under GNU/GPL version 3
+    Licensed under GNU GPL version 3 <https://www.gnu.org/licenses/>
 
     Usage: torget [FLAGS] {file.txt | URL [URL2...]}
       -circuits, -c int
@@ -35,6 +35,8 @@ Onion services are fully supported.
             Minimum circuit lifetime (seconds). (default 10)
       -name, -n string
             Output filename. (default filename from URL)
+      -tor-port, -p int
+            Port your Tor service is listening on. (default 9050)
       -verbose, -v
             Show diagnostic details.
 

--- a/dist.ps1
+++ b/dist.ps1
@@ -1,7 +1,7 @@
 $OSes = @("windows", "linux", "freebsd", "openbsd", "netbsd", "darwin")
 $Env:GOARCH = "amd64"
 
-New-Item -Path "./dist/" -ItemType Directory
+New-Item -Path "./dist/" -ItemType Directory -ErrorAction SilentlyContinue
 
 $OSes | ForEach-Object {
     Write-Host "Building for $_..." -NoNewline
@@ -10,4 +10,4 @@ $OSes | ForEach-Object {
     Write-Host " Done" -ForegroundColor Green
 }
 
-Move-Item -Path "./dist/torget-windows" -Destination "./dist/torget.exe"
+Move-Item -Path "./dist/torget-windows" -Destination "./dist/torget.exe" -Force

--- a/dist.ps1
+++ b/dist.ps1
@@ -1,0 +1,13 @@
+$OSes = @("windows", "linux", "freebsd", "openbsd", "netbsd", "darwin")
+$Env:GOARCH = "amd64"
+
+New-Item -Path "./dist/" -ItemType Directory
+
+$OSes | ForEach-Object {
+    Write-Host "Building for $_..." -NoNewline
+    $Env:GOOS = $_
+    go build -o "./dist/torget-$_" -ldflags "-w -s" ".\torget.go"
+    Write-Host " Done" -ForegroundColor Green
+}
+
+Move-Item -Path "./dist/torget-windows" -Destination "./dist/torget.exe"

--- a/torget.go
+++ b/torget.go
@@ -63,7 +63,7 @@ type State struct {
 const torBlock = 8000 // the longest plain text block in Tor
 
 func httpClient(user string) *http.Client {
-	proxyUrl, _ := url.Parse("socks5://" + user + ":" + user + "@127.0.0.1:9050/")
+	proxyUrl, _ := url.Parse(fmt.Sprint("socks5://"+user+":"+user+"@127.0.0.1:%d/", torPort))
 	return &http.Client{
 		Transport: &http.Transport{Proxy: http.ProxyURL(proxyUrl)},
 	}
@@ -465,6 +465,7 @@ var destination string
 var force bool
 var minLifetime int
 var name string
+var torPort int
 var verbose bool
 
 func init() {
@@ -483,6 +484,9 @@ func init() {
 
 	flag.StringVar(&name, "name", "", "Output filename.")
 	flag.StringVar(&name, "n", "", "Output filename.")
+
+	flag.IntVar(&torPort, "tor-port", 9050, "Port your Tor service is listening on.")
+	flag.IntVar(&torPort, "p", 9050, "Port your Tor service is listening on.")
 
 	flag.BoolVar(&verbose, "verbose", false, "Show iagnostic details.")
 	flag.BoolVar(&verbose, "v", false, "Show iagnostic details.")
@@ -505,6 +509,8 @@ func init() {
 		fmt.Fprintln(os.Stderr, "        Minimum circuit lifetime (seconds). (default 10)")
 		fmt.Fprintln(os.Stderr, "  -name, -n string")
 		fmt.Fprintln(os.Stderr, "        Output filename. (default filename from URL)")
+		fmt.Fprintln(os.Stderr, "  -tor-port, -p int")
+		fmt.Fprintln(os.Stderr, "        Port your Tor service is listening on. (default 9050)")
 		fmt.Fprintln(os.Stderr, "  -verbose, -v")
 		fmt.Fprintln(os.Stderr, "        Show diagnostic details.")
 	}

--- a/torget.go
+++ b/torget.go
@@ -492,27 +492,28 @@ func init() {
 	flag.BoolVar(&verbose, "v", false, "Show iagnostic details.")
 
 	flag.Usage = func() {
-		fmt.Fprintln(os.Stderr, "torget 2.0, a fast large file downloader over locally installed Tor")
-		fmt.Fprintln(os.Stderr, "Copyright © 2021-2023 Michał Trojnara <Michal.Trojnara@stunnel.org>")
-		fmt.Fprintln(os.Stderr, "Licensed under GNU/GPL version 3")
-		fmt.Fprintln(os.Stderr)
-		fmt.Fprintln(os.Stderr, "Usage: torget [FLAGS] {file.txt | URL [URL2...]}")
+		w := flag.CommandLine.Output()
+
+		fmt.Fprintln(w, "torget 2.0, a fast large file downloader over locally installed Tor")
+		fmt.Fprintln(w, "Copyright © 2021-2023 Michał Trojnara <Michal.Trojnara@stunnel.org>")
+		fmt.Fprintln(w, "Licensed under GNU/GPL version 3")
+		fmt.Fprintln(w, "\nUsage: torget [FLAGS] {file.txt | URL [URL2...]}")
 
 		// Custom print out of the arguments to avoid duplicate entries for long and short versions
-		fmt.Fprintln(os.Stderr, "  -circuits, -c int")
-		fmt.Fprintln(os.Stderr, "        Concurrent circuits. (default 20)")
-		fmt.Fprintln(os.Stderr, "  -destination, -d string")
-		fmt.Fprintln(os.Stderr, "        Output directory. (default current directory)")
-		fmt.Fprintln(os.Stderr, "  -force bool")
-		fmt.Fprintln(os.Stderr, "        Will create parent folder(s) and/or overwrite existing files.")
-		fmt.Fprintln(os.Stderr, "  -min-lifetime, -l int")
-		fmt.Fprintln(os.Stderr, "        Minimum circuit lifetime (seconds). (default 10)")
-		fmt.Fprintln(os.Stderr, "  -name, -n string")
-		fmt.Fprintln(os.Stderr, "        Output filename. (default filename from URL)")
-		fmt.Fprintln(os.Stderr, "  -tor-port, -p int")
-		fmt.Fprintln(os.Stderr, "        Port your Tor service is listening on. (default 9050)")
-		fmt.Fprintln(os.Stderr, "  -verbose, -v")
-		fmt.Fprintln(os.Stderr, "        Show diagnostic details.")
+		fmt.Fprintln(w, "  -circuits, -c int")
+		fmt.Fprintln(w, "        Concurrent circuits. (default 20)")
+		fmt.Fprintln(w, "  -destination, -d string")
+		fmt.Fprintln(w, "        Output directory. (default current directory)")
+		fmt.Fprintln(w, "  -force bool")
+		fmt.Fprintln(w, "        Will create parent folder(s) and/or overwrite existing files.")
+		fmt.Fprintln(w, "  -min-lifetime, -l int")
+		fmt.Fprintln(w, "        Minimum circuit lifetime (seconds). (default 10)")
+		fmt.Fprintln(w, "  -name, -n string")
+		fmt.Fprintln(w, "        Output filename. (default filename from URL)")
+		fmt.Fprintln(w, "  -tor-port, -p int")
+		fmt.Fprintln(w, "        Port your Tor service is listening on. (default 9050)")
+		fmt.Fprintln(w, "  -verbose, -v")
+		fmt.Fprintln(w, "        Show diagnostic details.")
 	}
 }
 

--- a/torget.go
+++ b/torget.go
@@ -496,7 +496,7 @@ func init() {
 
 		fmt.Fprintln(w, "torget 2.0, a fast large file downloader over locally installed Tor")
 		fmt.Fprintln(w, "Copyright © 2021-2023 Michał Trojnara <Michal.Trojnara@stunnel.org>")
-		fmt.Fprintln(w, "Licensed under GNU/GPL version 3")
+		fmt.Fprintln(w, "Licensed under GNU GPL version 3 <https://www.gnu.org/licenses/>")
 		fmt.Fprintln(w, "\nUsage: torget [FLAGS] {file.txt | URL [URL2...]}")
 
 		// Custom print out of the arguments to avoid duplicate entries for long and short versions

--- a/torget.go
+++ b/torget.go
@@ -64,7 +64,7 @@ const torBlock = 8000 // The longest plain text block in Tor
 
 // Basic function to determine human-readable file sizes
 func humanReadableSize(sizeInBytes float32) string {
-	units := []string{"B", "KB", "MB", "GB", "TB"}
+	units := []string{"B", "KiB", "MiB", "GiB", "TiB"}
 	i := 0
 
 	for {

--- a/torget.go
+++ b/torget.go
@@ -60,7 +60,7 @@ type State struct {
 	rwmutex     sync.RWMutex
 }
 
-const torBlock = 8000 // the longest plain text block in Tor
+const torBlock = 8000 // The longest plain text block in Tor
 
 func httpClient(user string) *http.Client {
 	proxyUrl, _ := url.Parse(fmt.Sprint("socks5://"+user+":"+user+"@127.0.0.1:%d/", torPort))
@@ -137,7 +137,7 @@ func (s *State) chunkFetch(id int, client *http.Client, req *http.Request) {
 		return
 	}
 
-	// open the output file
+	// Open the output file
 	file, err := os.OpenFile(s.output, os.O_WRONLY, 0)
 	if err != nil {
 		s.log <- fmt.Sprintf("os OpenFile: %s", err.Error())
@@ -151,13 +151,13 @@ func (s *State) chunkFetch(id int, client *http.Client, req *http.Request) {
 		return
 	}
 
-	// copy network data to the output file
+	// Copy network data to the output file
 	buffer := make([]byte, torBlock)
 	for {
 		n, err := resp.Body.Read(buffer)
 		if n > 0 {
 			file.Write(buffer[:n])
-			// enough to RLock(), as we only modify our own chunk
+			// Enough to RLock(), as we only modify our own chunk
 			s.rwmutex.RLock()
 			if int64(n) < s.chunks[id].length {
 				s.chunks[id].start += int64(n)
@@ -211,9 +211,9 @@ func (s *State) printLogs() {
 	for i := 0; i < n; i++ {
 		logs[i] = <-s.log
 	}
-	logs[n] = "stop" // not an expected log line
+	logs[n] = "stop" // Not an expected log line
 	sort.Strings(logs)
-	prevLog := "start" // not an expected log line
+	prevLog := "start" // Not an expected log line
 	cnt := 0
 	for _, log := range logs {
 		if log == prevLog {
@@ -238,7 +238,7 @@ func (s *State) ignoreLogs() {
 }
 
 func (s *State) statusLine() (status string) {
-	// calculate bytes transferred since the previous invocation
+	// Calculate bytes transferred since the previous invocation
 	curr := s.bytesTotal
 	s.rwmutex.RLock()
 	for id := 0; id < s.circuits; id++ {
@@ -306,8 +306,6 @@ func (s *State) darwin() {
 		slowest = throughput
 	}
 	if victim >= 0 {
-		// fmt.Printf("killing %5.1fs %5.1fkB/s",
-		//	now.Sub(s.chunks[victim].since).Seconds(), slowest/1024.0)
 		s.chunks[victim].cancel()
 		s.chunks[victim].cancel = nil
 	}
@@ -330,12 +328,9 @@ func (s *State) getOutputFilepath() {
 	// If no -name argument provided, extract the filename from the URL
 	if name == "" {
 		srcUrl, _ := url.Parse(s.src) // We've already parsed the URL, ignore errors here
-		// if err != nil {
-		// 	fmt.Println(err.Error())
-		// 	return 1
-		// }
 		path := srcUrl.EscapedPath()
 		slash := strings.LastIndex(path, "/")
+
 		if slash >= 0 {
 			filename = path[slash+1:]
 		} else {
@@ -397,7 +392,7 @@ func (s *State) Fetch(src string) int {
 	// Initialize chunks
 	chunkLen := s.bytesTotal / int64(s.circuits)
 	seq := 0
-	for id := 0; id < s.circuits; id++ {
+	for id := range s.circuits {
 		s.chunks[id].start = int64(id) * chunkLen
 		s.chunks[id].length = chunkLen
 		s.chunks[id].circuit = seq
@@ -408,10 +403,10 @@ func (s *State) Fetch(src string) int {
 	// Spawn initial fetchers
 	go s.progress()
 	go func() {
-		for id := 0; id < s.circuits; id++ {
+		for id := range s.circuits {
 			client, req := s.chunkInit(id)
 			go s.chunkFetch(id, client, req)
-			time.Sleep(499 * time.Millisecond) // be gentle to the local tor daemon
+			time.Sleep(499 * time.Millisecond) // Be gentle to the local tor daemon
 		}
 	}()
 
@@ -584,5 +579,3 @@ func main() {
 		state.Fetch(uri)
 	}
 }
-
-// vim: noet:ts=4:sw=4:sts=4:spell


### PR DESCRIPTION
New features:

- New CLI argument: `-tor-port` - Allows you to specify the port your Tor service is listening on
- Human readable file sizes (e.g. "177206596 bytes" -> "155.83 MiB"
- PowerShell script to build binaries on Windows (or other platforms with PS installed)
- Lots of small code changes - formatting, error handling, comments, .gitignore