### PR TITLE
tor-dl 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ parallel. With slow servers, this strategy bypasses per-IP traffic shaping,
 resulting in much faster downloads. Onion services are fully supported.
 
 tor-dl is based on the work-in-progress 2.0 version of
-[torget by Michał Trojnara](https://github.com/mtrojnar/torget). The two most
+[torget by Michał Trojnara](https://github.com/mtrojnar/torget). The most
 impactful updates are:
 
 - Specify download destination folders and/or filenames
 - Download multiple files
+- Improved text output (including the ability to suppress it)
 
 ## Building From Source
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,14 @@ impactful updates are:
 
 ### View help page
     $ ./tor-dl -h
-    tor-dl -  fast large file downloader over locally installed Tor
+    tor-dl - fast large file downloader over locally installed Tor
     Copyright © 2025 Bryan Cuneo <https://github.com/BryanCuneo/tor-dl/>
     Based on torget by Michał Trojnara <https://github.com/mtrojnar/torget>
     Licensed under GNU GPL version 3 <https://www.gnu.org/licenses/>
 
     Usage: tor-dl [FLAGS] {file.txt | URL [URL2...]}
+      -allow-http bool
+            Allow tor-dl to download files over HTTP instead of HTTPS. Not recommended!
       -circuits, -c int
             Concurrent circuits. (default 20)
       -destination, -d string
@@ -130,3 +132,27 @@ You may pass the path of a text file containing multiple URLs on each line to do
     Output file: /music/ca200_Various__Clinical_Jazz_CD6.zip
     Download length: 159.02 MiB
     Download completed in 1m9s
+
+# A Note on Privacy
+Neither this tool nor Tor in general guarantees anonymity. Please review
+[this blog post](https://support.torproject.org/faq/staying-anonymous/) from
+the Tor Project for tips on protectecting yourself. Especially relevant to
+tor-dl is the section titled, "Don't open documents downloaded through Tor
+while online." tor-dl is primarily designed for the use case of evading
+network restrictions by routing your traffic through Tor. But it will have no
+impact on how you use the files after they've been downoloaded.
+
+## Downloads over HTTP
+By default, tor-dl will not allow you to download files over HTTP:
+
+    $ ./tor-dl http://archive.org/download/dracula_librivox/DraculaStoker_64kb_librivox.m4b
+    ERROR: "http://archive.org/download/dracula_librivox/DraculaStoker_64kb_librivox.m4b" is not using HTTPS.
+        If you absolutely must use HTTP, use the -allow-http flag. This is dangerous and not recommended!
+
+If you understand the privacy concerns and still want to download over HTTP
+anyway, you can use the `-allow-http` flag:
+
+    $ ./tor-dl -allow-http http://archive.org/download/dracula_librivox/DraculaStoker_64kb_librivox.m4b
+    Output file: DraculaStoker_64kb_librivox.m4b
+    Download length: 594.70 MiB
+    Download completed in 3m44s

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ impactful updates are:
     $ ./tor-dl -h
     tor-dl - fast large file downloader over locally installed Tor
     Copyright © 2025 Bryan Cuneo <https://github.com/BryanCuneo/tor-dl/>
-    Based on torget by Michał Trojnara <https://github.com/mtrojnar/torget>
     Licensed under GNU GPL version 3 <https://www.gnu.org/licenses/>
+    Based on torget by Michał Trojnara <https://github.com/mtrojnar/torget>
 
     Usage: tor-dl [FLAGS] {file.txt | URL [URL2...]}
       -allow-http bool
@@ -41,6 +41,10 @@ impactful updates are:
             Minimum circuit lifetime (seconds). (default 10)
       -name, -n string
             Output filename. (default filename from URL)
+      -quiet, -q bool
+            Suppress most text output (still show errors).
+      -silent, -s bool
+            Suppress all text output (including errors).
       -tor-port, -p int
             Port your Tor service is listening on. (default 9050)
       -verbose, -v

--- a/README.md
+++ b/README.md
@@ -52,46 +52,47 @@ impactful updates are:
 
 ### Download a file to the current directory
     $ ./tor-dl "https://archive.org/download/grimaces-birthday-game/Grimace%27s%20Birthday%20%28World%29%20%28v1.7%29%20%28Aftermarket%29%20%28Unl%29.gbc"
-    Output file: Grimace's Birthday (World) (v1.7) (Aftermarket) (Unl).gbc
-    Download length:   1.00 MiB
-    Download completed in 20s
+    Output file:            Grimace's Birthday (World) (v1.7) (Aftermarket) (Unl).gbc
+    Download filesize:      1.00 MiB
+    Download completed in:  16s (64.03 KiB/s)
 
 ### Specify a destination directory
-    $ ./tor-dl -destination "/isos" "https://cdimage.ubuntu.com/kubuntu/releases/24.10/release/kubuntu-24.10-desktop-amd64.iso"
-    Output file: /isos/kubuntu-24.10-desktop-amd64.isoDownload length:   4.36 GiB
-    Download completed in 5m43s
+    $ ./tor-dl -destination "/isos/" "https://download.tails.net/tails/stable/tails-amd64-6.13/tails-amd64-6.13.img"
+    Output file:            /isos/tails-amd64-6.13.img
+    Download filesize:      1.48 GiB
+    Download completed in:  2m28s (7.30 MiB/s)
 
 ### Specify a new name for the file
-    $ ./tor-dl -name "haiku-beta5-x86.iso" "https://mirrors.rit.edu/haiku/r1beta5/haiku-r1beta5-x86_gcc2h-anyboot.iso"
-    Output file: haiku-beta5-x86.iso
-    Download length:   1.38 GiB
-    Download completed in 1m47s
+    $ ./tor-dl -name "haiku-beta5-32bit.iso" "https://mirrors.rit.edu/haiku/r1beta5/haiku-r1beta5-x86_gcc2h-anyboot.iso"
+    Output file:            haiku-beta5-32bit.iso
+    Download filesize:      1.38 GiB
+    Download completed in:  3m46s (6.23 MiB/s)
 
 ### The -force flag
 By default, tor-dl will not create any parent directories or overwrite
 existing files. If the file already exists in your destination, then you
 will see the following error:
 
-    $ tor-dl -destination "/audiobooks/" "https://archive.org/download/dracula_librivox/DraculaStoker_64kb_librivox.m4b"                                   
+    $ tor-dl -destination "/audiobooks/" "https://archive.org/download/dracula_librivox/DraculaStoker_64kb_librivox.m4b"
     ERROR: "/audiobooks/DraculaStoker_64kb_librivox.m4b" already exists. Skipping.
 
 If instead a directory in your `-destination` path doesn't exist, you
 you will get a warning and the download will default to your current
 directory instead:
 
-    $ tor-dl -destination "/audiobooks/" "https://archive.org/download/dracula_librivox/DraculaStoker_64kb_librivox.m4b"      
+    $ tor-dl -destination "/audiobooks/" "https://archive.org/download/dracula_librivox/DraculaStoker_64kb_librivox.m4b"
     WARNING: Unable to find destination "/audiobooks/". Trying current directory instead.
-    Output file: DraculaStoker_64kb_librivox.m4b
-    Download length: 594.70 MiB
-    Download completed in 2m18s
+    Output file:            DraculaStoker_64kb_librivox.m4b
+    Download filesize:      594.70 MiB
+    Download completed in:  3m21s (2.97 MiB/s)
 
 To automatically create new drectories and/or overwrite existing files, you
 can use the `-force` flag:
 
-    $ tor-dl -force -destination "/audiobooks/" "https://archive.org/download/dracula_librivox/DraculaStoker_64kb_librivox.m4b"      
-    Output file: /audiobooks/DraculaStoker_64kb_librivox.m4b
-    Download length: 594.70 MiB
-    Download completed in 2m18s
+    $ tor-dl -force -destination "/audiobooks/" "https://archive.org/download/dracula_librivox/DraculaStoker_64kb_librivox.m4b"
+    Output file:            /audiobooks/DraculaStoker_64kb_librivox.m4b
+    Download filesize:      594.70 MiB
+    Download completed in:  3m21s (2.97 MiB/s)
 
 ## Downloading Multiple Files
 
@@ -102,19 +103,19 @@ You may pass more than one URL to tor-dl and download them all sequentially.
     Downloading 3 files.
 
     [1/3] - https://archive.org/download/ca200_cjazz/ca200_Various__Clinical_Jazz_CD1.zip
-    Output file: /music/ca200_Various__Clinical_Jazz_CD1.zip
-    Download length: 169.00 MiB
-    Download completed in 1m16s
+    Output file:            /music/ca200_Various__Clinical_Jazz_CD1.zip
+    Download filesize:      169.00 MiB
+    Download completed in:  55s (3.05 MiB/s) 
     
     [2/3] - https://archive.org/download/ca200_cjazz/ca200_Various__Clinical_Jazz_CD2v.zip
-    Output file: /music/ca200_Various__Clinical_Jazz_CD2v.zip
-    Download length: 135.64 MiB
-    Download completed in 1m5s
+    Output file:            /music/ca200_Various__Clinical_Jazz_CD2v.zip
+    Download filesize:      135.64 MiB
+    Download completed in:  1m2s (2.19 MiB/s)
     
     [3/3] - https://archive.org/download/ca200_cjazz/ca200_Various__Clinical_Jazz_CD3.zip
-    Output file: /music/ca200_Various__Clinical_Jazz_CD3.zip
-    Download length: 145.64 MiB
-    Download completed in 1m15s
+    Output file:            /music/ca200_Various__Clinical_Jazz_CD3.zip
+    Download filesize:      145.64 MiB
+    Download completed in:  56s (2.62 MiB/s)
 
 ### With a local text file
 You may pass the path of a text file containing multiple URLs on each line to
@@ -132,19 +133,19 @@ download them all sequentially.
     Downloading 3 files.
 
     [1/3] - https://archive.org/download/ca200_cjazz/ca200_Various__Clinical_Jazz_CD4.zip
-    Output file: /music/ca200_Various__Clinical_Jazz_CD4.zip
-    Download length: 155.83 MiB
-    Download completed in 1m13s
+    Output file:            /music/ca200_Various__Clinical_Jazz_CD4.zip
+    Download filesize:      155.83 MiB
+    Download completed in:  46s (3.41 MiB/s)
     
     [2/3] - https://archive.org/download/ca200_cjazz/ca200_Various__Clinical_Jazz_CD5.zip
-    Output file: /music/ca200_Various__Clinical_Jazz_CD5.zip
-    Download length: 152.86 MiB
-    Download completed in 1m4s
+    Output file:            /music/ca200_Various__Clinical_Jazz_CD5.zip
+    Download filesize:      152.86 MiB
+    Download completed in:  39s (3.93 MiB/s)
     
     [3/3] - https://archive.org/download/ca200_cjazz/ca200_Various__Clinical_Jazz_CD6.zip
-    Output file: /music/ca200_Various__Clinical_Jazz_CD6.zip
-    Download length: 159.02 MiB
-    Download completed in 1m9s
+    Output file:            /music/ca200_Various__Clinical_Jazz_CD6.zip
+    Download filesize:      159.02 MiB
+    Download completed in:  55s (2.87 MiB/s)
 
 # A Note on Privacy
 Neither this tool nor Tor in general guarantees anonymity. Please review
@@ -166,6 +167,6 @@ If you understand the privacy concerns and still want to download over HTTP
 anyway, you can use the `-allow-http` flag:
 
     $ ./tor-dl -allow-http "http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_native_60fps_normal.mp4"
-    Output file: bbb_sunflower_native_60fps_normal.mp4
-    Download length: 793.33 MiB
-    Download completed in 2m52s
+    Output file:            bbb_sunflower_native_60fps_normal.mp4
+    Download filesize:      793.33 MiB
+    Download completed in:  2m57s (4.47 MiB/s)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ impactful updates are:
 - Specify download destination folders and/or filenames
 - Download multiple files
 - Improved text output (including the ability to suppress it)
+- Safer default behavior (no overwriting files, no non-HTTPS downloads)
 
 ## Building From Source
 

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ will see the following error:
     ERROR: "/audiobooks/DraculaStoker_64kb_librivox.m4b" already exists. Skipping.
 
 If instead a directory in your `-destination` path doesn't exist, you
-you will get a warning the download will default to your current directory
-instead:
+you will get a warning and the download will default to your current
+directory instead:
 
     $ tor-dl -destination "/audiobooks/" "https://archive.org/download/dracula_librivox/DraculaStoker_64kb_librivox.m4b"      
     WARNING: Unable to find destination "/audiobooks/". Trying current directory instead.
@@ -85,7 +85,8 @@ instead:
     Download length: 594.70 MiB
     Download completed in 2m18s
 
-To automatically create new drectories and/or overwrite existing files, you can use the `-force` flag:
+To automatically create new drectories and/or overwrite existing files, you
+can use the `-force` flag:
 
     $ tor-dl -force -destination "/audiobooks/" "https://archive.org/download/dracula_librivox/DraculaStoker_64kb_librivox.m4b"      
     Output file: /audiobooks/DraculaStoker_64kb_librivox.m4b
@@ -116,7 +117,8 @@ You may pass more than one URL to tor-dl and download them all sequentially.
     Download completed in 1m15s
 
 ### With a local text file
-You may pass the path of a text file containing multiple URLs on each line to download them all sequentially.
+You may pass the path of a text file containing multiple URLs on each line to
+download them all sequentially.
 
 #### /music/downloads.txt
     

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ impactful updates are:
     $ cd tor-dl
     $ go build tor-dl.go
 
-## Using
+## Usage
 
 ### View help page
     $ ./tor-dl -h
@@ -68,22 +68,29 @@ impactful updates are:
     Download completed in 1m47s
 
 ### The -force flag
-Use the -force flag to create parent directories and/or overwrite existing files
+By default, tor-dl will not create any parent directories or overwrite
+existing files. If the file already exists in your destination, then you
+will see the following error:
 
-    $ ./tor-dl -force -destination "/movies/Big Buck Bunny - Sunflower version (2013)" -name "Big Buck Bunny - Sunflower Version (2013).mp4" "http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_native_60fps_normal.mp4"
-    Output file: /movies/Big Buck Bunny - Sunflower version (2013)/Big Buck Bunny - Sunflower Version (2013).mp4
-    Download length: 793.33 MiB
-    Download completed in 2m52s
+    $ tor-dl -destination "/audiobooks/" "https://archive.org/download/dracula_librivox/DraculaStoker_64kb_librivox.m4b"                                   
+    ERROR: "/audiobooks/DraculaStoker_64kb_librivox.m4b" already exists. Skipping.
 
-If the destination directory is not found, the program will try downloading to the current directory instead.
+If instead a directory in your `-destination` path doesn't exist, you
+you will get a warning the download will default to your current directory
+instead:
 
-    WARNING: Unable to find destination "/movies/Big Buck Bunny - Sunflower version (2013)".
-    Trying current directory instead.
+    $ tor-dl -destination "/audiobooks/" "https://archive.org/download/dracula_librivox/DraculaStoker_64kb_librivox.m4b"      
+    WARNING: Unable to find destination "/audiobooks/". Trying current directory instead.
+    Output file: DraculaStoker_64kb_librivox.m4b
+    Download length: 594.70 MiB
+    Download completed in 2m18s
 
-If the file already exists, you will receive an error.
+To automatically create new drectories and/or overwrite existing files, you can use the `-force` flag:
 
-    ERROR: "/movies/Big Buck Bunny - Sunflower version (2013)/Big Buck Bunny - Sunflower Version (2013).mp4" already exists.
-    exit status 1
+    $ tor-dl -force -destination "/audiobooks/" "https://archive.org/download/dracula_librivox/DraculaStoker_64kb_librivox.m4b"      
+    Output file: /audiobooks/DraculaStoker_64kb_librivox.m4b
+    Download length: 594.70 MiB
+    Download completed in 2m18s
 
 ## Downloading Multiple Files
 
@@ -143,20 +150,20 @@ Neither this tool nor Tor in general guarantees anonymity. Please review
 the Tor Project for tips on protectecting yourself. Especially relevant to
 tor-dl is the section titled, "Don't open documents downloaded through Tor
 while online." tor-dl is primarily designed for the use case of evading
-network restrictions by routing your traffic through Tor. But it will have no
+network restrictions by routing your traffic through Tor and it will have no
 impact on how you use the files after they've been downoloaded.
 
 ## Downloads over HTTP
 By default, tor-dl will not allow you to download files over HTTP:
 
-    $ ./tor-dl http://archive.org/download/dracula_librivox/DraculaStoker_64kb_librivox.m4b
-    ERROR: "http://archive.org/download/dracula_librivox/DraculaStoker_64kb_librivox.m4b" is not using HTTPS.
-        If you absolutely must use HTTP, use the -allow-http flag. This is dangerous and not recommended!
+    $ ./tor-dl "http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_native_60fps_normal.mp4"
+    ERROR: "http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_native_60fps_normal.mp4" is not using HTTPS.
+    	If you absolutely must use HTTP, use the -allow-http flag. This is dangerous and not recommended!
 
 If you understand the privacy concerns and still want to download over HTTP
 anyway, you can use the `-allow-http` flag:
 
-    $ ./tor-dl -allow-http http://archive.org/download/dracula_librivox/DraculaStoker_64kb_librivox.m4b
-    Output file: DraculaStoker_64kb_librivox.m4b
-    Download length: 594.70 MiB
-    Download completed in 3m44s
+    $ ./tor-dl -allow-http "http://distribution.bbb3d.renderfarming.net/video/mp4/bbb_sunflower_native_60fps_normal.mp4"
+    Output file: bbb_sunflower_native_60fps_normal.mp4
+    Download length: 793.33 MiB
+    Download completed in 2m52s

--- a/tor-dl.go
+++ b/tor-dl.go
@@ -332,7 +332,7 @@ func (s *State) getOutputFilepath() {
 		if force {
 			os.MkdirAll(destination, os.ModePerm)
 		} else {
-			fmt.Fprintf(messageWriter, "WARNING: Unable to find destination \"%s\".\nTrying current directory instead.\n", destination)
+			fmt.Fprintf(messageWriter, "WARNING: Unable to find destination \"%s\". Trying current directory instead.\n", destination)
 			destination = "."
 		}
 	}


### PR DESCRIPTION
Version 2.1 release.

New features:
- Ability to suppress console output with two new CLI arguments:
  - `-quiet` - Suppress most console output but still show any errors.
  - `-silent` - Suppress all console output, including errors
- Now show the average speed after a download is completed
- By default, do not allow downloads from non-HTTPS URLs. This can be ignored with the `-allow-http` CLI argument

Bug fixes:
- Fixed an issue where download speed would be displayed incorrectly in the progress message

Misc:
- Updated README, including a new section with a privacy warning.